### PR TITLE
fix: use channelId to find log instead of cached value

### DIFF
--- a/src/modules/generateLogs.ts
+++ b/src/modules/generateLogs.ts
@@ -19,11 +19,10 @@ export const generateLogs = async (
   channelId: string
 ): Promise<AttachmentBuilder> => {
   try {
-    const logName = Bot.ticketLogs[channelId];
     delete Bot.ticketLogs[channelId];
 
     const logs = await readFile(
-      join(process.cwd(), "logs", `${logName}.txt`),
+      join(process.cwd(), "logs", `${channelId}.txt`),
       "utf8"
     ).catch(() => "no logs found...");
 
@@ -31,7 +30,7 @@ export const generateLogs = async (
       name: "log.txt",
     });
 
-    await unlink(join(process.cwd(), "logs", `${logName}.txt`));
+    await unlink(join(process.cwd(), "logs", `${channelId}.txt`));
 
     return attachment;
   } catch (err) {


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

This will fix the issue of restarts breaking the logs.

<!--A brief description of what your pull request does.-->

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
